### PR TITLE
refactor: テンプレートファイルをWorkbookとして読み込むメソッドの名前を変更

### DIFF
--- a/src/main/java/com/qwerty0121/poi/sample/AddImageSample.java
+++ b/src/main/java/com/qwerty0121/poi/sample/AddImageSample.java
@@ -15,7 +15,7 @@ import com.qwerty0121.poi.utils.PoiSampleUtils;
 public class AddImageSample {
 
   public static void main(String[] args) throws IOException {
-    try (var workbook = PoiSampleUtils.createWorkbook("画像追加サンプルテンプレート.xlsx");) {
+    try (var workbook = PoiSampleUtils.loadTemplateWorkbook("画像追加サンプルテンプレート.xlsx");) {
       // "テスト"シートを取得
       var sheet = workbook.getSheet("テスト");
 

--- a/src/main/java/com/qwerty0121/poi/sample/ChangeShapeStackingOrder.java
+++ b/src/main/java/com/qwerty0121/poi/sample/ChangeShapeStackingOrder.java
@@ -17,7 +17,7 @@ import com.qwerty0121.poi.utils.PoiSampleUtils;
 public class ChangeShapeStackingOrder {
 
   public static void main(String[] args) throws IOException {
-    try (var workbook = PoiSampleUtils.createWorkbook("図形重なり順変更テンプレート.xlsx");) {
+    try (var workbook = PoiSampleUtils.loadTemplateWorkbook("図形重なり順変更テンプレート.xlsx");) {
       // "テスト"シートを取得
       var sheet = workbook.getSheet("テスト");
 

--- a/src/main/java/com/qwerty0121/poi/sample/HideShapeSample.java
+++ b/src/main/java/com/qwerty0121/poi/sample/HideShapeSample.java
@@ -15,7 +15,7 @@ import com.qwerty0121.poi.utils.PoiSampleUtils;
 public class HideShapeSample {
 
   public static void main(String[] args) throws IOException {
-    try (var workbook = PoiSampleUtils.createWorkbook("図形非表示サンプルテンプレート.xlsx");) {
+    try (var workbook = PoiSampleUtils.loadTemplateWorkbook("図形非表示サンプルテンプレート.xlsx");) {
       // "テスト"シートを取得
       var sheet = workbook.getSheet("テスト");
 

--- a/src/main/java/com/qwerty0121/poi/sample/RemoveShapeSample.java
+++ b/src/main/java/com/qwerty0121/poi/sample/RemoveShapeSample.java
@@ -13,7 +13,7 @@ import com.qwerty0121.poi.utils.PoiSampleUtils;
 public class RemoveShapeSample {
 
   public static void main(String[] args) throws IOException {
-    try (var workbook = PoiSampleUtils.createWorkbook("図形削除サンプルテンプレート.xlsx");) {
+    try (var workbook = PoiSampleUtils.loadTemplateWorkbook("図形削除サンプルテンプレート.xlsx");) {
       // "テスト"シートを取得
       var sheet = workbook.getSheet("テスト");
 

--- a/src/main/java/com/qwerty0121/poi/utils/PoiSampleUtils.java
+++ b/src/main/java/com/qwerty0121/poi/utils/PoiSampleUtils.java
@@ -17,13 +17,13 @@ import org.apache.poi.xssf.usermodel.XSSFShape;
 public class PoiSampleUtils {
 
   /**
-   * テンプレートファイルからWorkbookを作成する
+   * テンプレートファイルをWorkbookとして読み込む
    * 
    * @param templateFileName テンプレートファイル名
    * @return Workbook
    * @throws IOException
    */
-  public static Workbook createWorkbook(String templateFileName) throws IOException {
+  public static Workbook loadTemplateWorkbook(String templateFileName) throws IOException {
     try (
         var templateFileIS = PoiSampleUtils.class.getClassLoader()
             .getResourceAsStream(templateFileName);) {


### PR DESCRIPTION
"作成"というよりは"読み込む"なので、"create〜"ではなく"load〜"に変更した。  
また、テンプレートファイルのWorkbookを読み込むことがわかりやすいように"Template"という単語も追加した。