### PR TITLE
docs: 条件付き書式のコピー処理に対する注意事項をコメントに追加

### DIFF
--- a/src/main/java/com/qwerty0121/poi/sample/SheetCopyToOtherWorkbookSample.java
+++ b/src/main/java/com/qwerty0121/poi/sample/SheetCopyToOtherWorkbookSample.java
@@ -168,7 +168,12 @@ public class SheetCopyToOtherWorkbookSample {
   /**
    * シート条件付き書式をコピーする<br>
    * <br>
-   * 条件種別が数式以外である場合はコピーされないので注意
+   * 以下の設定はコピーできないので注意。
+   * <ul>
+   * <li>条件を満たす場合は停止</li>
+   * </ul>
+   * <br>
+   * また、現状では条件種別が数式以外である場合はコピーされないので注意
    * 
    * @param srcSheetConditionalFormatting  コピー元のシート条件付き書式
    * @param destSheetConditionalFormatting コピー先のシート条件付き書式


### PR DESCRIPTION
シートを別ワークブックにコピーするサンプルについて、条件付き書式をコピーするメソッドに対する注意事項をコメントに追加した。